### PR TITLE
Linting run against amqp_queue_check

### DIFF
--- a/nagios/amqp_queue_check.py
+++ b/nagios/amqp_queue_check.py
@@ -37,9 +37,11 @@
 # DAMAGE.
 #
 ########################################################################################
-import sys, os, socket, struct
+import sys
+import socket
+import struct
+from argparse import ArgumentParser
 from amqplib import client_0_8 as amqp
-from optparse import OptionParser
 
 
 ### Constants
@@ -48,66 +50,65 @@ EXIT_NAGIOS_WARN = 1
 EXIT_NAGIOS_CRITICAL = 2
 
 ### Validate Commandline Arguments
-opt_parser = OptionParser()
+opt_parser = ArgumentParser()
 
-opt_parser.add_option("-s", "--server", dest="server",
-                      help="AMQP server to connect to.")
-opt_parser.add_option("-v", "--vhost", dest="vhost",
-                      help="Virtual host to log on to.")
-opt_parser.add_option("-u", "--user", dest="user",
-                      help="Username to use when authenticating with server.")
-opt_parser.add_option("-p", "--password", dest="password",
-                      help="Password to use when authenticating with server.")
-opt_parser.add_option("-q", "--queue", dest="queue_name",
-                      help="Queue name to check.")
-opt_parser.add_option("-d", "--durable", action="store_true", dest="durable",
-                      default="False", help="Declare queue as durable. (Default: False)")
-opt_parser.add_option("-a", "--auto-delete", action="store_true", dest="auto_delete",
-                      default="False", help="Declare queue as auto-delete. (Default: False)")
-opt_parser.add_option("-w", "--warn", dest="warn_threshold",
-                      help="Number of unacknowledged messages that triggers a warning status.")
-opt_parser.add_option("-c", "--critical", dest="critical_threshold",
-                      help="Number of unacknowledged messages that triggers a critical status.")
+opt_parser.add_argument("-s", "--server", dest="server",
+                        help="AMQP server to connect to.")
+opt_parser.add_argument("-v", "--vhost", dest="vhost",
+                        help="Virtual host to log on to.")
+opt_parser.add_argument("-u", "--user", dest="user",
+                        help="Username to use when authenticating with server.")
+opt_parser.add_argument("-p", "--password", dest="password",
+                        help="Password to use when authenticating with server.")
+opt_parser.add_argument("-q", "--queue", dest="queue_name",
+                        help="Queue name to check.")
+opt_parser.add_argument("-d", "--durable", action="store_true", dest="durable",
+                        default="False", help="Declare queue as durable. (Default: False)")
+opt_parser.add_argument("-a", "--auto-delete", action="store_true", dest="auto_delete",
+                        default="False", help="Declare queue as auto-delete. (Default: False)")
+opt_parser.add_argument("-w", "--warn", dest="warn_threshold",
+                        help="Number of unacknowledged messages that triggers a warning status.")
+opt_parser.add_argument("-c", "--critical", dest="critical_threshold",
+                        help="Number of unacknowledged messages that triggers a critical status.")
 
+args = opt_parser.parse_args()
 
-args = opt_parser.parse_args()[0]
-
-if args.server == None:
-    print "An AMQP server (--server) must be supplied. Please see --help for more details."
+if args.server is None:
+    print("An AMQP server (--server) must be supplied. Please see --help for more details.")
     sys.exit(-1)
-if args.vhost == None:
-    print "A virtual host (--vhost) must be supplied. Please see --help for more details."
+if args.vhost is None:
+    print("A virtual host (--vhost) must be supplied. Please see --help for more details.")
     sys.exit(-1)
-if args.user == None:
-    print "A username (--user) to use when authenticating with AMQP server must be supplied. " \
-          "Please see --help for more details."
+if args.user is None:
+    print("A username (--user) to use when authenticating with AMQP server must be supplied. " \
+          "Please see --help for more details.")
     sys.exit(-1)
-if args.password == None:
-    print "A password (--password) to use when authenticating with AMQP server must be supplied. " \
-          "Please see --help for more details."
+if args.password is None:
+    print("A password (--password) to use when authenticating with AMQP server must be supplied. " \
+          "Please see --help for more details.")
     sys.exit(-1)
-if args.queue_name == None:
-    print "A queue name (--queue) must be supplied. Please see --help for more details."
+if args.queue_name is None:
+    print("A queue name (--queue) must be supplied. Please see --help for more details.")
     sys.exit(-1)
-if args.warn_threshold == None:
-    print "A warning threshold (--warn) must be supplied. Please see --help for more details."
+if args.warn_threshold is None:
+    print("A warning threshold (--warn) must be supplied. Please see --help for more details.")
     sys.exit(-1)
 try:
     warn_threshold = int(args.warn_threshold)
     if warn_threshold < 0:
         raise ValueError
-except ValueError, e:
-    print "Warning threshold (--warn) must be a positive integer. Please see --help for more details."
+except ValueError:
+    print("Warning threshold (--warn) must be a positive integer. Please see --help for more details.")
     sys.exit(-1)
-if args.critical_threshold == None:
-    print "A critical threshold (--critical) must be supplied. Please see --help for more details."
+if args.critical_threshold is None:
+    print("A critical threshold (--critical) must be supplied. Please see --help for more details.")
     sys.exit(-1)
 try:
     critical_threshold = int(args.critical_threshold)
     if critical_threshold < 0:
         raise ValueError
-except ValueError, e:
-    print "Critical threshold (--critical) must be a positive integer. Please see --help for more details."
+except ValueError:
+    print("Critical threshold (--critical) must be a positive integer. Please see --help for more details.")
     sys.exit(-1)
 
 
@@ -125,27 +126,27 @@ try:
                                         passive=True)
 except (socket.error,
       amqp.AMQPConnectionException,
-      amqp.AMQPChannelException), e:
-    print "CRITICAL: Problem establishing MQ connection to server %s: %s " \
-          % (str(args.server), str(repr(e)))
+      amqp.AMQPChannelException) as exc:
+    print("CRITICAL: Problem establishing MQ connection to server %s: %s " \
+          % (str(args.server), str(repr(exc))))
     sys.exit(EXIT_NAGIOS_CRITICAL)
-except struct.error, e:
-    print "CRITICAL: Authentication error connecting to vhost '%s' on server '%s'." % \
-          (str(args.vhost), str(args.server))
+except struct.error:
+    print("CRITICAL: Authentication error connecting to vhost '%s' on server '%s'." % \
+          (str(args.vhost), str(args.server)))
     sys.exit(EXIT_NAGIOS_CRITICAL)
 
 mq_chan.close()
 mq_conn.close()
 
 if int(queue_stats[1]) >= critical_threshold:
-    print "CRITICAL: %s unacknowledged messages in queue '%s' on vhost '%s', server '%s'." % \
-          (str(queue_stats[1]), args.queue_name, str(args.vhost), str(args.server))
+    print("CRITICAL: %s unacknowledged messages in queue '%s' on vhost '%s', server '%s'." % \
+          (str(queue_stats[1]), args.queue_name, str(args.vhost), str(args.server)))
     sys.exit(EXIT_NAGIOS_CRITICAL)
 elif int(queue_stats[1]) >= warn_threshold:
-    print "WARN: %s unacknowledged messages in queue '%s' on vhost '%s', server '%s'." % \
-          (str(queue_stats[1]), args.queue_name, str(args.vhost), str(args.server))
+    print("WARN: %s unacknowledged messages in queue '%s' on vhost '%s', server '%s'." % \
+          (str(queue_stats[1]), args.queue_name, str(args.vhost), str(args.server)))
     sys.exit(EXIT_NAGIOS_WARN)
 else:
-    print "OK: %s unacknowledged messages in queue '%s' on vhost '%s', server '%s'." % \
-          (str(queue_stats[1]), args.queue_name, str(args.vhost), str(args.server))
+    print("OK: %s unacknowledged messages in queue '%s' on vhost '%s', server '%s'." % \
+          (str(queue_stats[1]), args.queue_name, str(args.vhost), str(args.server)))
     sys.exit(EXIT_NAGIOS_OK)


### PR DESCRIPTION
Did a little modernization run against nagios/amqp_queue_check.  Should be good in both py2 and py3 now (`print` is in parentheses), and eliminates the deprecated `optparse` in favor of `argparse`.